### PR TITLE
Adding fuzzy string matching for station names and better handling of user and Alex returned values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@ python app.py
 # to open local server to Alexa. Get https URL and past into endpoint URL config page in Alexa developer console
 ./ngrok http 5000
 
-
+# /data/*Dict.txt
+these files are used to map Alexa responses to specific, handled values.
+TODO: create automated way of creating Dict files from inputs from MTA

--- a/app.py
+++ b/app.py
@@ -34,7 +34,8 @@ station_dict = dict_from_file("data/StationDict.txt")
 
 def welome():
 
-    welcome_msg = "welcome to Subway Status! You can ask What lines are available? or When is the next uptown train?"
+    welcome_msg = "welcome to Subway Status! You can ask What lines are available? " + \
+    "or When is the next uptown 6 train at Union Square?"
 
     return question(welcome_msg)
 
@@ -66,15 +67,31 @@ def available_lines():
     
 @ask.intent("NextSubwayIntent")
 ## This intent is to get the next arrival times for a given subway line
-
+    
 def next_subway(direction,train,station):
+    print("Intent: NextSubwayIntent")
 
-    # hardcode a station ID, route, and line for now
+    # print what Alexa returned for each slot. Helps with debugging.
     print("direction: " + str(direction))
     print("train: " + str(train))
     print("station: " + str(station))
     
+    # If Alexa returns 'None' for a slot value, we can't continue, so let user know what is missing.
+    missing_msg = ""
+    if (direction == 'None'):
+        missing_msg += "I did not hear which direction you want, such as 'Uptown', 'Downtown', or 'Brooklyn Bound'. "
+    if (train == 'None'):
+        missing_msg += "I did not hear which train you want, such as 'Six train' or 'L train'. "
+    if (station == 'None'):
+        missing_msg += "I did not hear which station you want, such as 'Union Square' or 'West 4th Street'. "
+    
+    if (missing_msg != ""):
+        print(missing_msg)
+        return statement(missing_msg)
+    
+    
     # lookup user-spoken direction, train, and station to get standardized values
+    
     try:
         train_direction = direction_dict[str(direction).lower()]
     except KeyError:
@@ -86,14 +103,18 @@ def next_subway(direction,train,station):
         return statement("Sorry, I don't understand train " + str(train))
         
     try:
+        # use fuzzy matching on station names in StationDict.txt to determine which station id to query
+        # TODO: look into converting numbers ordinals (eg, 42nd) to words in the dict and the Alexa response
+        #       to improve quality of station name matching
+        # TODO: look into subsetting the list of stations to attempt to match based on the user's stated train
+        #       line. For example, when user is asking for 6 train, only consider stations along the 6 route. This
+        #       addresses problem of similary named stations (ie, 14th street, 42nd street)
         station_match = process.extractOne(str(station).lower(), station_dict.keys(), scorer=fuzz.token_set_ratio)[0] 
         print("Station Match:" + str(station_match))
         station_id = station_dict[str(station_match)]
         print("Station ID: " + str(station_id))
     except KeyError:
         return statement("Sorry, I don't understand station " + str(station))
-    
-    print("Intent: NextSubwayIntent")
     
     MTARequest = requests.get(mta_api_url + "/by-id/" + str(station_id))
     
@@ -106,6 +127,7 @@ def next_subway(direction,train,station):
 
     times = []
     
+    # Look through MTA response and get next arrival times and time in minutes from now
     for train in data['data'][0][train_direction]:
         if (train['route']==train_name):
             time = parser.parse(train['time'])
@@ -123,9 +145,7 @@ def stop():
     print ("Intent: AMAZON.StopIntent")
     return statement("Goodbye.")
  
-    
-          
-
+ 
 if __name__ == '__main__':
 
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import json
 from flask import Flask, render_template
 from flask_ask import Ask, statement, question, session
 from dateutil import parser
+from fuzzywuzzy import process, fuzz
 
 ## URL of MTA realtime subway API. I am hosting on Lambda
 mta_api_url = "https://pbdexmgg8g.execute-api.us-east-1.amazonaws.com/dev"
@@ -85,13 +86,16 @@ def next_subway(direction,train,station):
         return statement("Sorry, I don't understand train " + str(train))
         
     try:
-        station_id = station_dict[str(station).lower()]
+        station_match = process.extractOne(str(station).lower(), station_dict.keys(), scorer=fuzz.token_set_ratio)[0] 
+        print("Station Match:" + str(station_match))
+        station_id = station_dict[str(station_match)]
+        print("Station ID: " + str(station_id))
     except KeyError:
         return statement("Sorry, I don't understand station " + str(station))
     
     print("Intent: NextSubwayIntent")
     
-    MTARequest = requests.get(mta_api_url + "/by-id/" + station_id)
+    MTARequest = requests.get(mta_api_url + "/by-id/" + str(station_id))
     
     data = json.loads(MTARequest.text)
     

--- a/data/TrainDict.txt
+++ b/data/TrainDict.txt
@@ -2,6 +2,8 @@ one|1
 1|1
 two|2
 2|2
+to|2
+too|2
 three|3
 3|3
 four|4

--- a/data/TrainDict.txt
+++ b/data/TrainDict.txt
@@ -5,6 +5,7 @@ two|2
 three|3
 3|3
 four|4
+for|4
 4|4
 five|5
 5|5

--- a/speechAssets/customSlotTypes/TRAIN.txt
+++ b/speechAssets/customSlotTypes/TRAIN.txt
@@ -2,6 +2,7 @@ one
 two
 three
 four
+for
 five
 six
 El


### PR DESCRIPTION
We can't control how user will specify a station name. We also can't control how Alexa will return the results to the app. So, in order to query MTA api, we need specific names/ids. We can use fuzzy string matching to find the best match of explicit station names based on response from Alexa.

Also adding handling of cases where user doesn't give station, direction, and train or when the combination of station and train doesn't actually exist.