### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/app_utils.py
+++ b/app_utils.py
@@ -1,7 +1,7 @@
 import requests
 import json
 from dateutil import parser
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 
 def dict_from_file(file):
     """ Returns a dict object based on a file of pipe-delimited key/value pairs """

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ durationpy==0.5
 Flask==0.12.1
 Flask-Ask==0.9.7
 future==0.18.2
-fuzzywuzzy==0.18.0
 hjson==3.0.1
 idna==2.9
 importlib-metadata==1.6.0
@@ -30,6 +29,7 @@ pyOpenSSL==17.0.0
 python-dateutil==2.6.1
 python-slugify==4.0.0
 PyYAML==3.13
+rapidfuzz==0.7.6
 requests==2.23.0
 s3transfer==0.3.3
 six==1.11.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy